### PR TITLE
Refactor to get rid of CharacterController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,5 @@ Assets/Plugins/polyperfect/
 # Local user settings.
 UserSettings/
 
+# Test builds.
 test_build*

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ Assets/Plugins/polyperfect/
 
 # Local user settings.
 UserSettings/
+
+test_build*

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -211,7 +211,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 366215642}
-  - component: {fileID: 366215645}
   - component: {fileID: 366215644}
   m_Layer: 0
   m_Name: Player
@@ -253,28 +252,9 @@ MonoBehaviour:
     PlayerRunSpeed: 10
     JumpHeight: 1
     GravityValue: 9.81
-    RotationSpeed: 30
-  characterController: {fileID: 366215645}
+    RotationSpeed: 15
   playerShoulderTarget: {fileID: 996116154}
   gameInput: {fileID: 297956314}
---- !u!143 &366215645
-CharacterController:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 366215641}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Height: 2
-  m_Radius: 0.5
-  m_SlopeLimit: 45
-  m_StepOffset: 0.3
-  m_SkinWidth: 0.0001
-  m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 1, z: 0}
 --- !u!1 &427920523
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameInput.cs
+++ b/Assets/Scripts/GameInput.cs
@@ -12,10 +12,10 @@ public class GameInput : MonoBehaviour
         playerInputActions.Player.Enable();
     }
 
-    public Vector2 GetMovement()
+    public Vector3 GetMovement()
     {
-        var movement = playerInputActions.Player.Move.ReadValue<Vector2>();
-        return Vector2.ClampMagnitude(movement, 1f);
+        var move = playerInputActions.Player.Move.ReadValue<Vector2>();
+        return Vector3.ClampMagnitude(new Vector3(move.x, 0f, move.y), 1f);
     }
 
     public Vector2 GetLookAround()

--- a/Assets/Scripts/GameInput.cs
+++ b/Assets/Scripts/GameInput.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 public class GameInput : MonoBehaviour
@@ -13,9 +12,10 @@ public class GameInput : MonoBehaviour
         playerInputActions.Player.Enable();
     }
 
-    public Vector2 GetMovementNormalized()
+    public Vector2 GetMovement()
     {
-        return playerInputActions.Player.Move.ReadValue<Vector2>().normalized;
+        var movement = playerInputActions.Player.Move.ReadValue<Vector2>();
+        return Vector2.ClampMagnitude(movement, 1f);
     }
 
     public Vector2 GetLookAround()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,16 +1,13 @@
 using System;
 using UnityEngine;
 
-/// <summary>
-/// Enables a GameObject to move with WASD and jump with Space.
-/// </summary>
-[RequireComponent(typeof(CharacterController))]
 public class PlayerController : MonoBehaviour
 {
     [Serializable]
     struct Configuration
     {
         public float PlayerWalkSpeed;
+
         public float PlayerRunSpeed;
 
         /// <summary>
@@ -46,11 +43,6 @@ public class PlayerController : MonoBehaviour
         /// Time elapsed since last frame.
         /// </summary>
         public float DeltaTime;
-
-        /// <summary>
-        /// Whether player is grounded.
-        /// </summary>
-        public bool IsGrounded;
     }
 
     [SerializeField]
@@ -65,10 +57,6 @@ public class PlayerController : MonoBehaviour
 
     [SerializeField]
     [NotNull]
-    CharacterController characterController;
-
-    [SerializeField]
-    [NotNull]
     Transform playerShoulderTarget;
 
     [SerializeField]
@@ -76,6 +64,7 @@ public class PlayerController : MonoBehaviour
     GameInput gameInput;
 
     CurrentInput currentInput;
+
     float verticalSpeed;
 
     public float HorizontalSpeed
@@ -85,37 +74,19 @@ public class PlayerController : MonoBehaviour
     }
 
     /// <summary>
-    /// Used to compute currentSpeed. Do not use otherwise.
+    /// Used to compute HorizontalSpeed. Do not use otherwise.
     /// </summary>
     float horizontalSpeedDampingValue;
 
-    static CurrentInput GetCurrentInput(CharacterController controller, GameInput gameInput)
+    static CurrentInput GetCurrentInput(GameInput gameInput)
     {
-        var movement = gameInput.GetMovementNormalized();
-        var input = new Vector3(movement.x, 0f, movement.y);
+        var move = gameInput.GetMovement();
         return new CurrentInput
         {
-            Move = Vector3.ClampMagnitude(input, 1f),
+            Move = new Vector3(move.x, 0f, move.y),
             Run = gameInput.GetRun(),
             DeltaTime = Time.smoothDeltaTime,
-            IsGrounded = controller.isGrounded,
         };
-    }
-
-    static float UpdateVerticalVelocity(float verticalVelocity, CurrentInput currentInput, Configuration config)
-    {
-        // Simulate force of gravity.
-        verticalVelocity -= config.GravityValue * Time.deltaTime;
-
-        // However,
-        if (currentInput.IsGrounded && verticalVelocity < 0)
-        {
-            // Then zero out y-component of velocity.
-            // Must be slightly negative so that CharacterController's .isGrounded computation returns true.
-            verticalVelocity = -.5f;
-        }
-
-        return verticalVelocity;
     }
 
     private float TargetSpeed
@@ -135,8 +106,7 @@ public class PlayerController : MonoBehaviour
 
     private void Update()
     {
-        currentInput = GetCurrentInput(characterController, gameInput);
-        verticalSpeed = UpdateVerticalVelocity(verticalSpeed, currentInput, configuration);
+        currentInput = GetCurrentInput(gameInput);
         HorizontalSpeed = Mathf.SmoothDamp(HorizontalSpeed, TargetSpeed, ref horizontalSpeedDampingValue, .3f);
 
         var yRotation = Quaternion.Euler(0f, playerShoulderTarget.eulerAngles.y, 0f);
@@ -147,8 +117,7 @@ public class PlayerController : MonoBehaviour
 
     private void Move(Vector3 movementDirection)
     {
-        characterController.Move(currentInput.DeltaTime * HorizontalSpeed * movementDirection);
-        characterController.Move(currentInput.DeltaTime * new Vector3(0f, verticalSpeed, 0f));
+        transform.position += currentInput.DeltaTime * HorizontalSpeed * movementDirection;
     }
 
     private void FaceMovementDirection(Vector3 movementDirection)

--- a/ProjectSettings/BurstAotSettings_StandaloneOSX.json
+++ b/ProjectSettings/BurstAotSettings_StandaloneOSX.json
@@ -1,0 +1,16 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "EnableArmv9SecurityFeatures": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/ProjectSettings/CommonBurstAotSettings.json
+++ b/ProjectSettings/CommonBurstAotSettings.json
@@ -1,6 +1,6 @@
 {
   "MonoBehaviour": {
-    "Version": 3,
+    "Version": 4,
     "DisabledWarnings": ""
   }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/URPSampleScene.unity
-    guid: 99c9720ab356a0642a771bea13969a05
+    path: Assets/Scenes/Game.unity
+    guid: 3579100dc72eb420496990c1eb7e11a0
   m_configObjects: {}


### PR DESCRIPTION
## JIRA Ticket

> Sorry folks, this is internal to my Notion workspace!

> https://www.notion.so/nucleartide/Extract-CharacterController-92f60493d53346b3962c5abe5fbb5169?pvs=4

## Changelog

> Provide a bulleted list of changes that were made in this pull request.

* Consolidate input logic in `GameInput`
* Remove `CharacterController` from `PlayerController` class, and simplify logic
* Fix build settings so that correct scene is included in build

## How it works

> Explain what you did, how you did it, and why you did it. Also any lessons that might be useful to others.
>
> (Note to self: it's easiest to do a stream-of-consciousness writeup of what you did.)

I've seen on YouTube videos that avoiding Unity Physics and CharacterControllers is best if one wants to add multiplayer support to their game later on.

So this pull request gets rid of the CharacterController that is currently part of the `Player` GameObject. Nothing changes from a player point of view, but the internal logic is far simpler.

## Quality Assurance

> Take some screenshots as confirmation of quality assurance.

You can indeed still walk, run around, and rotate the camera:

<img width="1582" alt="Screenshot 2023-03-01 at 3 03 27 PM" src="https://user-images.githubusercontent.com/914228/222253185-3c39df16-dd78-47d4-ae8b-7b7a30d09fab.png">