### PR TITLE
Add playtesting step to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 * [ ] **Editable**: Has any configuration been moved into ScriptableObjects, so that modified values persist even after exiting Play mode?
 * [ ] **Debuggable**: Do you have debug views for the prefabs/systems that you are creating?
 * [ ] Update readme with new pull request.
+* [ ] **Playtesting**: If you have a design hypothesis that you'd like to test, try playtesting with friends, family, Twitter, or folks on Discord.
 
 ## Changelog
 


### PR DESCRIPTION
Contrary to the process described in [Better Playtesting for Indie Developers](https://github.com/nucleartide/GameDevLectures/blob/c6a7fe3957313dc544eb422d2c506e63006b9ff6/Better_Playtesting_for_Indie_Developers.md), this step entails an informal playtest with friends or family.

A more formal playtest would be an entire piece of work in itself.