### PR TITLE
Add `ThirdPartyAssets/` as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Assets/Plugins/ThirdPartyAssets"]
+	path = Assets/Plugins/ThirdPartyAssets
+	url = git@github.com:nucleartide/Breadforge-ThirdPartyAssets.git

--- a/Readme.md
+++ b/Readme.md
@@ -146,6 +146,7 @@ I wrote a [blog post on LinkedIn](https://www.linkedin.com/pulse/why-you-should-
 | Feature | Pull Request |
 | --- | --- |
 | Make everything unlit + copy assets over from Polyperfect asset pack | https://github.com/nucleartide/Breadforge/pull/58 |
+| Add `ThirdPartyAssets/` as git submodule | https://github.com/nucleartide/Breadforge/pull/60 |
 | *This is currently being worked on. Check back soon for updates!* | |
 
 <br />


### PR DESCRIPTION
...so as not to commit licensed assets to the [public Breadforge project](https://github.com/nucleartide/Breadforge).

## Workflow

The following commands add a new git submodule to the project:

```sh
git submodule add git@github.com:nucleartide/Breadforge-ThirdPartyAssets.git Assets/Plugins/ThirdPartyAssets
git add .
git commit -m "Blah blah"
```

You can then track the history of the submodule separately from the main repo.

However, note that if you change a git submodule's contents, you must make two commits:

1. You must commit the changes to the submodule *first*.
2. Then, you must commit the updated submodule reference to the parent repo.